### PR TITLE
Update Node.js version from v12 to v24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,5 +7,5 @@ inputs:
   files:
     description: list of files to scan (newline separated)
 runs:
-  using: node12
+  using: node24
   main: action/index.dist.js


### PR DESCRIPTION
Fix annotation at https://github.com/winfsp/winfsp/actions/runs/23510354555
* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners